### PR TITLE
Use autoprefixer instead of autoprefixer-core

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,11 +43,11 @@ Show help
 
 Use autoprefixer as a postcss plugin pass parameters from a json file
 
-    postcss --use autoprefixer-core -c options.json -o screen.css screen.css
+    postcss --use autoprefixer -c options.json -o screen.css screen.css
 
 Use more than one plugin and pass config parameters
 
-    postcss --use autoprefixer-core --autoprefixer-code.browsers "> 5%" \
+    postcss --use autoprefixer --autoprefixer.browsers "> 5%" \
         --use postcss-cachify --postcss-cachify.baseUrl /res \
         -o screen.css screen.css
 


### PR DESCRIPTION
`autoprefixer-core` will be deprectated in next major release. So we can make docs cleaner.

And your binary will replace `autoprefixer` CLI tool.
