### PR TITLE
allow specifying CLI options in config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: clean lint test
 lint:
 	./node_modules/.bin/jshint *.js
 
-TESTS = opts stdout stdin safe config js-config invalid
+TESTS = opts stdout stdin safe config config-all js-config js-config-all invalid
 DIFF = diff -q
 
 test: test/build test-help test-version $(patsubst %,test/build/%.css,$(TESTS)) test-multi
@@ -41,8 +41,16 @@ test/build/config.css: test/in.css
 	./bin/postcss -u postcss-url -c test/config.json -o $@ $<
 	$(DIFF) $@ $(subst build,ref,$@)
 
+test/build/config-all.css: test/in.css
+	./bin/postcss -c test/config-all.json
+	$(DIFF) $@ $(subst build,ref,$@)
+
 test/build/js-config.css: test/in.css
 	./bin/postcss -u postcss-url -c test/config.js -o $@ $<
+	$(DIFF) $@ $(subst build,ref,$@)
+
+test/build/js-config-all.css: test/in.css
+	./bin/postcss -c test/config-all.js
 	$(DIFF) $@ $(subst build,ref,$@)
 
 test/build:

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,8 @@ Output files location. Either `--output` or `--dir` option, but not both of them
 
 #### `--use|-u`
 
-Plugin to be used. Multiple plugins can be specified. At least one is required.
+Plugin to be used. Multiple plugins can be specified. At least one is required unless specified
+within config file.
 
 #### `--config|-c`
 
@@ -59,6 +60,21 @@ module.exports = {
 };
 ````
 Alternatively configuration options can be passed as `--plugin.option` parameters.
+
+Note that command-line options can also be specified in the config file:
+
+````json
+{
+    "use": ["autoprefixer", "postcss-cachify"],
+    "output": "bundle.css",
+    "autoprefixer": {
+        "browsers": "> 5%"
+    },
+    "postcss-cachify": {
+        "baseUrl": "/res"
+    }
+}
+````
 
 ### `--safe`
 

--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,7 @@ Note that command-line options can also be specified in the config file:
 ````json
 {
     "use": ["autoprefixer", "postcss-cachify"],
+    "input": "screen.css",
     "output": "bundle.css",
     "autoprefixer": {
         "browsers": "> 5%"

--- a/index.js
+++ b/index.js
@@ -101,18 +101,19 @@ function processCSS(processor, input, output, fn) {
   ], fn);
 }
 
-if (!argv._.length) {
-  // use stdin if nothing else is specified
-  argv._ = argv.input || [undefined];
-  if (!Array.isArray(argv._)) {
-    argv._ = [argv._];
+var inputs = argv._;
+if (!inputs.length) {
+  if(argv.input) {
+    inputs = Array.isArray(argv.input) ? argv.input : [argv.input];
+  } else { // use stdin if nothing else is specified
+    inputs = [undefined];
   }
 }
-if (argv._.length > 1 && !argv.dir) {
+if (inputs.length > 1 && !argv.dir) {
   throw 'Please specify --dir [output directory] for your files';
 }
 
-async.forEach(argv._, function(input, fn) {
+async.forEach(inputs, function(input, fn) {
   var output = argv.output;
   if (argv.dir) {
     output = path.join(argv.dir, path.basename(input));

--- a/index.js
+++ b/index.js
@@ -11,11 +11,12 @@ var argv = require("yargs")
   .describe('c', 'JSON file with plugin configuration')
   .alias('u', 'use')
   .describe('u', 'postcss plugin name (can be used multiple times)')
+  .alias('i', 'input')
   .alias('o', 'output')
   .describe('o', 'Output file (stdout if not provided)')
   .alias('d', 'dir')
   .describe('d', 'Output directory')
-  .requiresArg(['u', 'c', 'o', 'd'])
+  .requiresArg(['u', 'c', 'i', 'o', 'd'])
   .boolean('safe')
   .describe('safe', 'Enable postcss safe mode.')
   .version(function() {
@@ -28,8 +29,8 @@ var argv = require("yargs")
   .help('h')
   .alias('h', 'help')
   .check(function(argv) {
-    if (argv._.length > 1 && !argv.dir) {
-      throw 'Please specify --dir [output directory] for your files';
+    if (argv._.length && argv.input) {
+      throw 'Both positional arguments and --input option used for `input file`: please only use one of them.';
     }
     if (argv.output && argv.dir) {
       throw 'Both `output file` and `output directory` provided: please use either --output or --dir option.';
@@ -102,7 +103,13 @@ function processCSS(processor, input, output, fn) {
 
 if (!argv._.length) {
   // use stdin if nothing else is specified
-  argv._ = [undefined];
+  argv._ = argv.input || [undefined];
+  if (!Array.isArray(argv._)) {
+    argv._ = [argv._];
+  }
+}
+if (argv._.length > 1 && !argv.dir) {
+  throw 'Please specify --dir [output directory] for your files';
 }
 
 async.forEach(argv._, function(input, fn) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ var argv = require("yargs")
   .describe('c', 'JSON file with plugin configuration')
   .alias('u', 'use')
   .describe('u', 'postcss plugin name (can be used multiple times)')
-  .demand('u', 'Please specify at least one plugin name.')
   .alias('o', 'output')
   .describe('o', 'Output file (stdout if not provided)')
   .alias('d', 'dir')
@@ -39,6 +38,9 @@ var argv = require("yargs")
   })
   .argv;
 
+if (!argv.use) {
+  throw 'Please specify at least one plugin name.';
+}
 if (!Array.isArray(argv.use)) {
   argv.use = [argv.use];
 }

--- a/test/config-all.js
+++ b/test/config-all.js
@@ -1,0 +1,8 @@
+module.exports = {
+  use: "postcss-url",
+  input: "test/in.css",
+  output: "test/build/js-config-all.css",
+  "postcss-url": {
+    url: function(url) { return "http://example.com/" + url; }
+  }
+};

--- a/test/config-all.json
+++ b/test/config-all.json
@@ -1,0 +1,8 @@
+{
+  "use": "postcss-url",
+  "input": "test/in.css",
+  "output": "test/build/config-all.css",
+  "postcss-url": {
+    "url": "inline"
+  }
+}

--- a/test/ref/config-all.css
+++ b/test/ref/config-all.css
@@ -1,0 +1,4 @@
+body {
+  background: url(data:image/png;base64,bm90IHJlYWxseSBhbiBpbWFnZQo=);
+  display: flex;
+}

--- a/test/ref/js-config-all.css
+++ b/test/ref/js-config-all.css
@@ -1,0 +1,4 @@
+body {
+  background: url(http://example.com/image.png);
+  display: flex;
+}


### PR DESCRIPTION
having both -u|--use and input files in the config file means all PostCSS settings are bundled in one place

in my case, I went from

```
$ postcss -u postcss-use -c postcss.config.js -o bundle.css index.css
```

to

```
$ postcss -c postcss.config.js
```

which made sense because I was having a config file anyway
