### PR TITLE
remove obsolete note on postcss-import compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,8 +55,6 @@ into account:
 }
 ```
 
-[postcss-import] does not have 5.x compatible version as of now. See workaround [here](https://github.com/code42day/postcss-cli/issues/24).
-
 #### `--config|-c`
 
 JSON file with plugin configuration. Plugin names should be the keys.


### PR DESCRIPTION
postcss-import has since been updated (cf. #24, https://github.com/postcss/postcss-import/issues/75)
