### PR TITLE
feat: add glob support to argv for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var globby = require("globby");
 var argv = require("yargs")
   .usage('Usage: $0 -use plugin [--config|-c config.json] [--output|-o output.css] [input.css]')
   .example('postcss --use autoprefixer -c options.json -o screen.css screen.css',
@@ -52,7 +53,7 @@ if (!Array.isArray(argv.use)) {
   argv.use = [argv.use];
 }
 
-var inputFiles = argv._;
+var inputFiles = globby.sync(argv._);
 if (!inputFiles.length) {
   if (argv.input) {
     inputFiles = Array.isArray(argv.input) ? argv.input : [argv.input];

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Damian Krzeminski <pirxpilot@code42day.com>",
   "license": "MIT",
   "dependencies": {
+    "globby": "^3.0.1",
     "neo-async": "^1.0.0",
     "postcss": "^5.0.0",
     "read-file-stdin": "^0.2.0",


### PR DESCRIPTION
## Purpose of this PR

This is a place to talk about glob support for Windows (ref: #23 #14) and to provide an initial fix.
ping @hokiecoder. Not sure how far you got in #23.
## Specific breaking issue

This fixes the error I was getting when I was running this specific configuration of postcss:
`postcss --use autoprefixer -c postcss.config.json dist/css/*.css -d dist/css`
## Misc

`npm run test` still passes.
