### PR TITLE
Input files can now be replaced with generated output to keep directory tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 TESTS = opts stdout stdin config config-all js-config js-config-all invalid
 DIFF = diff -q
 
-test: test/build test-help test-version $(patsubst %,test/build/%.css,$(TESTS)) test-multi
+test: test/build test-help test-version $(patsubst %,test/build/%.css,$(TESTS)) test-multi test-replace
 
 test-help:
 	./bin/postcss --help
@@ -17,6 +17,11 @@ test-version:
 test-multi:
 	./bin/postcss -u postcss-url --dir test/build test/multi*.css
 	$(DIFF) test/build/multi*.css --to-file=test/ref
+
+test-replace:
+	 cp test/replace.css test/build/replace.css
+	./bin/postcss -u postcss-url --postcss-url.url "inline" --replace test/build/replace.css
+	$(DIFF) test/build/replace.css test/ref/replace.css
 
 test-watch: test/import-*.css
 	echo '@import "import-foo.css";' > test/import-index.css
@@ -66,4 +71,4 @@ test/build:
 clean:
 	rm -rf test/build
 
-.PHONY: all lint clean test test-help test-version test-multi test-watch
+.PHONY: all lint clean test test-help test-version test-multi test-watch test-replace

--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ npm install postcss-cli
 
 ## Usage
 
-    postcss [options] [-o output-file|-d output-directory] [input-file]
+    postcss [options] [-o output-file|-d output-directory|-r] [input-file]
 
 #### `--output|-o`
 
@@ -29,8 +29,13 @@ Plugins that rely on input file location will not work properly.
 
 #### `--dir|-d`
 
-Output files location. Either `--output` or `--dir` option, but not both of them, need to be specified.
-`--dir` needs to be used if multiple input file is provided.
+Output files location. Either `--output`, `--dir` or `--replace` option, but not all of them, need to be specified.
+`--dir` or `--replace` needs to be used if multiple input file is provided.
+
+#### `--replace|-r`
+
+Replace input file(s) with generated output. Either `--output`, `--dir` or `--replace` option, but not all of them, need to be specified.
+`--replace` or `--dir` needs to be used if multiple input file is provided.
 
 #### `--use|-u`
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ var argv = require("yargs")
   .describe('o', 'Output file (stdout if not provided)')
   .alias('d', 'dir')
   .describe('d', 'Output directory')
+  .boolean('r')
+  .alias('r', 'replace')
+  .describe('r', 'Replace input file(s) with generated output')
   .alias('s', 'syntax')
   .describe('s', 'Custom syntax')
   .alias('p', 'parser')
@@ -42,8 +45,17 @@ var argv = require("yargs")
     if (argv._.length && argv.input) {
       throw 'Both positional arguments and --input option used for `input file`: please only use one of them.';
     }
+    if (argv.output && argv.dir && argv.replace) {
+      throw '`output file`, `output directory` and `replace` provided: please use either --output, --dir or --replace option only.';
+    }
     if (argv.output && argv.dir) {
       throw 'Both `output file` and `output directory` provided: please use either --output or --dir option.';
+    }
+    if (argv.output && argv.replace) {
+      throw 'Both `output file` and `replace` provided: please use either --output or --replace option.';
+    }
+    if (argv.dir && argv.replace) {
+      throw 'Both `output directory` and `replace` provided: please use either --dir or --replace option.';
     }
     return true;
   })
@@ -61,8 +73,8 @@ if (!inputFiles.length) {
     inputFiles = [undefined];
   }
 }
-if (inputFiles.length > 1 && !argv.dir) {
-  throw 'Please specify --dir [output directory] for your files';
+if (inputFiles.length > 1 && !argv.dir && !argv.replace) {
+  throw 'Please specify either --replace or --dir [output directory] for your files';
 }
 
 // load and configure plugin array
@@ -110,6 +122,8 @@ function compile(input, fn) {
   var output = argv.output;
   if (argv.dir) {
     output = path.join(argv.dir, path.basename(input));
+  } else if (argv.replace) {
+    output = input;
   }
   processCSS(processor, input, output, fn);
 }

--- a/test/ref/replace.css
+++ b/test/ref/replace.css
@@ -1,0 +1,4 @@
+body {
+  background: url(data:image/png;base64,bm90IHJlYWxseSBhbiBpbWFnZQo=);
+  display: flex;
+}

--- a/test/replace.css
+++ b/test/replace.css
@@ -1,0 +1,4 @@
+body {
+  background: url(../image.png);
+  display: flex;
+}


### PR DESCRIPTION
We want to migrate from the "old" `autoprefixer` / `autoprefixer-cli` to the (now) recommended `postcss-cli`.

With `autoprefixer` 5.2.1 / `autoprefixer-cli` 1.0.0 it was possible to skip the `output` and `dir` arguments - in this case the input files were overwritten with the generated output (files).
I would love to see the same behaviour in postcss-cli as well. We use this behaviour in our build environment - we copy a directory tree containing css files and then run `autoprefixer` on those file - which keeps the directory tree / file structure. Keeping the file tree structure is not possible right now with `postcss-cli --use autoprefixer -d somedir` because all processed css files will be saved directly in the output dir, no matter if they came from a sub-directory or not.

In `autoprefixer-cli` for example this happend [in this](https://github.com/ai/autoprefixer-cli/blob/1.0.0/binary.js#L328-L332) `else` part.
