### PR TITLE
try use local package first, global package second

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules
+/node_modules
 test/build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ lint:
 TESTS = opts stdout stdin config config-all js-config js-config-all invalid
 DIFF = diff -q
 
-test: test/build test-help test-version $(patsubst %,test/build/%.css,$(TESTS)) test-multi test-replace
+test: test/build test-help test-version $(patsubst %,test/build/%.css,$(TESTS)) test-multi test-replace test-local-plugins
 
 test-help:
 	./bin/postcss --help
@@ -33,6 +33,9 @@ test-watch: test/import-*.css
 	$(DIFF) test/build/watch.css test/ref/watch-2.css
 	kill `cat test/watch.pid` # FIXME: never reached on failure
 	rm test/watch.pid
+
+test-local-plugins:
+	cd test; ../bin/postcss --use a-dummy-plugin --local-plugins -o build/local-plugins in.css
 
 test/build/opts.css: test/in.css
 	./bin/postcss -u postcss-url --postcss-url.url=rebase -o $@ $<

--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,11 @@ Replace input file(s) with generated output. Either `--output`, `--dir` or `--re
 Plugin to be used. Multiple plugins can be specified. At least one is required unless specified
 within config file.
 
+#### `--local-plugins`
+
+Lookup plugins in the current `node_modules` directory. 
+Without this option, postcss-cli Will lookup plugins in the global `node_modules` directory.
+
 #### `--watch|-w`
 
 Observe file system changes and recompile as source files change.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var globby = require("globby");
+var resolve = require("resolve");
 var argv = require("yargs")
   .usage('Usage: $0 -use plugin [--config|-c config.json] [--output|-o output.css] [input.css]')
   .example('postcss --use autoprefixer -c options.json -o screen.css screen.css',
@@ -79,7 +80,13 @@ if (inputFiles.length > 1 && !argv.dir && !argv.replace) {
 
 // load and configure plugin array
 var plugins = argv.use.map(function(name) {
-  var plugin = require(name);
+  var plugin;
+  try {
+    var resolved = resolve.sync(name, {basedir: process.cwd()});
+    plugin = require(resolved);
+  } catch (e) {
+    plugin = require(name);
+  }
   if (name in argv) {
     plugin = plugin(argv[name]);
   } else {

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ var argv = require("yargs")
   .describe('c', 'JSON file with plugin configuration')
   .alias('u', 'use')
   .describe('u', 'postcss plugin name (can be used multiple times)')
+  .option('local-plugins', {
+    describe: 'lookup plugins in current node_modules directory'
+  })
   .alias('i', 'input')
   .alias('o', 'output')
   .describe('o', 'Output file (stdout if not provided)')
@@ -80,11 +83,12 @@ if (inputFiles.length > 1 && !argv.dir && !argv.replace) {
 
 // load and configure plugin array
 var plugins = argv.use.map(function(name) {
+  var local = argv['local-plugins'];
   var plugin;
-  try {
+  if (local) {
     var resolved = resolve.sync(name, {basedir: process.cwd()});
     plugin = require(resolved);
-  } catch (e) {
+  } else {
     plugin = require(name);
   }
   if (name in argv) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "neo-async": "^1.0.0",
     "postcss": "^5.0.0",
     "read-file-stdin": "^0.2.0",
+    "resolve": "^1.1.6",
     "yargs": "^3.8.0"
   },
   "optionalDependencies": {

--- a/test/node_modules/a-dummy-plugin/index.js
+++ b/test/node_modules/a-dummy-plugin/index.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+}
+
+module.exports.postcss = function() {
+}


### PR DESCRIPTION
This pull request attempts to fix issues like #16, so that we don't need to install postcss plugins to global.

It adds a new dependency `resolve`, which is used in `browserify`
